### PR TITLE
[feat] Draw align

### DIFF
--- a/utils/skiplist_test.go
+++ b/utils/skiplist_test.go
@@ -16,6 +16,8 @@ package utils
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
@@ -67,6 +69,20 @@ func Benchmark_SkipListBasicCRUD(b *testing.B) {
 		searchVal := list.Search([]byte(key))
 		assert.Equal(b, searchVal.Value, []byte(val))
 	}
+}
+
+func TestDrawList(t *testing.T) {
+	list := NewSkiplist(1000)
+	n := 12
+	for i:=0; i<n; i++ {
+		index := strconv.Itoa(r.Intn(90)+10)
+		key := index + RandString(8)
+		entryRand := NewEntry([]byte(key), []byte(index))
+		list.Add(entryRand)
+	}
+	list.Draw(true)
+	fmt.Println(strings.Repeat("*", 30) + "分割线" + strings.Repeat("*", 30))
+	list.Draw(false)
 }
 
 func TestConcurrentBasic(t *testing.T) {
@@ -123,7 +139,7 @@ func Benchmark_ConcurrentBasic(b *testing.B) {
 			defer wg.Done()
 			v := l.Search(key(i))
 			require.EqualValues(b, key(i), v.Value)
-			require.Nil(b, v)
+			require.NotNil(b, v)
 		}(i)
 	}
 	wg.Wait()


### PR DESCRIPTION
添加绘制SkipList的方法skiplist.Draw(align bool). 也改了几个命名, 修了一个不正确测试用例.

1. align=true时, 会把每层同一个节点对齐.

2. align=false不对齐, 直接顺序打印出每一层的节点.

写了个测试用例
```bash
cd utils
go test -run=TestDrawList
```
效果如下图所示: 
![image](https://user-images.githubusercontent.com/9164258/165428322-da33703f-dfce-4084-9f62-3745c880ad16.png)
