### PR TITLE
[test] add TestCacheSameKey case

### DIFF
--- a/utils/cache/cache_test.go
+++ b/utils/cache/cache_test.go
@@ -26,3 +26,20 @@ func TestCacheBasicCRUD(t *testing.T) {
 
 	}
 }
+
+
+func TestCacheSameKey(t *testing.T) {
+	cache := NewCache(500)
+	key := "one"
+	for i := 0; i < 10; i++ {
+		val := fmt.Sprintf("val%d", i)
+		cache.Set(key, val)
+		res, ok := cache.Get(key)
+		if ok {
+			assert.Equal(t, val, res)
+			continue
+		}
+		assert.Equal(t, res, nil)
+	}
+}
+


### PR DESCRIPTION
cache增加同key加入的testcase:
```bash
cd utils/cache/
go test -run=TestCacheSameKey
```
测试结果显示有点儿问题:
```bash
--- FAIL: TestCacheSameKey (0.00s)
    cache_test.go:39: 
                Error Trace:    cache_test.go:39
                Error:          Not equal: 
                                expected: "val5"
                                actual  : "val0"
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -val5
                                +val0
                Test:           TestCacheSameKey
    cache_test.go:39: 
                Error Trace:    cache_test.go:39
                Error:          Not equal: 
                                expected: "val6"
                                actual  : "val1"
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -val6
                                +val1
                Test:           TestCacheSameKey
    cache_test.go:39: 
                Error Trace:    cache_test.go:39
                Error:          Not equal: 
                                expected: "val7"
                                actual  : "val2"
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -val7
                                +val2
                Test:           TestCacheSameKey
    cache_test.go:39: 
                Error Trace:    cache_test.go:39
                Error:          Not equal: 
                                expected: "val8"
                                actual  : "val3"
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -val8
                                +val3
                Test:           TestCacheSameKey
    cache_test.go:39: 
                Error Trace:    cache_test.go:39
                Error:          Not equal: 
                                expected: "val9"
                                actual  : "val4"
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -val9
                                +val4
                Test:           TestCacheSameKey
FAIL
exit status 1
FAIL    github.com/hardcore-os/corekv/utils/cache       0.050s
```