### PR TITLE
[fix] Cache fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
 work_test
 testdata
+.idea

--- a/utils/cache/cache.go
+++ b/utils/cache/cache.go
@@ -2,9 +2,10 @@ package cache
 
 import (
 	"container/list"
-	xxhash "github.com/cespare/xxhash/v2"
 	"sync"
 	"unsafe"
+
+	xxhash "github.com/cespare/xxhash/v2"
 )
 
 type Cache struct {
@@ -211,4 +212,10 @@ func MemHashString(str string) uint64 {
 func MemHash(data []byte) uint64 {
 	ss := (*stringStruct)(unsafe.Pointer(&data))
 	return uint64(memhash(ss.str, 0, uintptr(ss.len)))
+}
+
+func (c *Cache) String() string {
+	var s string
+	s += c.lru.String() + " | " + c.slru.String()
+	return s
 }

--- a/utils/cache/cache.go
+++ b/utils/cache/cache.go
@@ -84,7 +84,7 @@ func (c *Cache) set(key, value interface{}) bool {
 		return true
 	}
 
-	if !c.door.Allow(uint32(keyHash)) {
+	if !c.door.Allow(uint32(eitem.key)) {
 		return true
 	}
 
@@ -117,6 +117,7 @@ func (c *Cache) get(key interface{}) (interface{}, bool) {
 
 	val, ok := c.data[keyHash]
 	if !ok {
+		c.door.Allow(uint32(keyHash))
 		c.c.Increment(keyHash)
 		return nil, false
 	}
@@ -124,10 +125,11 @@ func (c *Cache) get(key interface{}) (interface{}, bool) {
 	item := val.Value.(*storeItem)
 
 	if item.conflict != conflictHash {
+		c.door.Allow(uint32(keyHash))
 		c.c.Increment(keyHash)
 		return nil, false
 	}
-
+	c.door.Allow(uint32(keyHash))
 	c.c.Increment(item.key)
 
 	v := item.value

--- a/utils/cache/cache_test.go
+++ b/utils/cache/cache_test.go
@@ -2,8 +2,9 @@ package cache
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCacheBasicCRUD(t *testing.T) {
@@ -12,6 +13,7 @@ func TestCacheBasicCRUD(t *testing.T) {
 		key := fmt.Sprintf("key%d", i)
 		val := fmt.Sprintf("val%d", i)
 		cache.Set(key, val)
+		fmt.Printf("set %s: %s\n", key, cache)
 	}
 
 	for i := 0; i < 1000; i++ {
@@ -19,10 +21,11 @@ func TestCacheBasicCRUD(t *testing.T) {
 		val := fmt.Sprintf("val%d", i)
 		res, ok := cache.Get(key)
 		if ok {
+			fmt.Printf("get %s: %s\n", key, cache)
 			assert.Equal(t, val, res)
 			continue
 		}
 		assert.Equal(t, res, nil)
-
 	}
+	fmt.Printf("at last: %s\n", cache)
 }

--- a/utils/cache/lru.go
+++ b/utils/cache/lru.go
@@ -1,6 +1,9 @@
 package cache
 
-import "container/list"
+import (
+	"container/list"
+	"fmt"
+)
 
 type windowLRU struct {
 	data map[uint64]*list.Element
@@ -43,4 +46,12 @@ func (lru *windowLRU) add(newitem storeItem) (eitem storeItem, evicted bool) {
 
 func (lru *windowLRU) get(v *list.Element) {
 	lru.list.MoveToFront(v)
+}
+
+func (lru *windowLRU) String() string {
+	var s string
+	for e := lru.list.Front(); e != nil; e = e.Next() {
+		s += fmt.Sprintf("%v,", e.Value.(*storeItem).value)
+	}
+	return s
 }

--- a/utils/cache/s2lru.go
+++ b/utils/cache/s2lru.go
@@ -1,6 +1,9 @@
 package cache
 
-import "container/list"
+import (
+	"container/list"
+	"fmt"
+)
 
 type segmentedLRU struct {
 	data                     map[uint64]*list.Element
@@ -9,7 +12,7 @@ type segmentedLRU struct {
 }
 
 const (
-	STAGE_ONE = iota
+	STAGE_ONE = iota + 1
 	STAGE_TWO
 )
 
@@ -83,4 +86,16 @@ func (slru *segmentedLRU) victim() *storeItem {
 
 	v := slru.stageOne.Back()
 	return v.Value.(*storeItem)
+}
+
+func (slru *segmentedLRU) String() string {
+	var s string
+	for e := slru.stageTwo.Front(); e != nil; e = e.Next() {
+		s += fmt.Sprintf("%v,", e.Value.(*storeItem).value)
+	}
+	s += fmt.Sprintf(" | ")
+	for e := slru.stageOne.Front(); e != nil; e = e.Next() {
+		s += fmt.Sprintf("%v,", e.Value.(*storeItem).value)
+	}
+	return s
 }


### PR DESCRIPTION
发现的2个小问题:
1. https://github.com/hardcore-os/corekv/blob/014c8872a41dec98a963cc0b18eb9d036df592dd/utils/cache/s2lru.go#L12
这个STAGE_ONE是不是应该是iota + 1呀?  windowLRU才是0.

2. https://github.com/hardcore-os/corekv/blob/014c8872a41dec98a963cc0b18eb9d036df592dd/utils/cache/cache.go#L86
还有这一行是不是应该用wlru淘汰出来的key呀? 而不是本次插入的key

3. 顺便添加了打印cache缓存的方法, 按照lru|StageTwo|StageOne排布, 比如: 
```bash
cd utils/cache
go test -v
=== RUN   TestCacheBasicCRUD
set key0: val0, |  | 
set key1: val1, |  | val0,
set key2: val2, |  | val1,val0,
set key3: val3, |  | val2,val1,val0,
set key4: val4, |  | val3,val2,val1,val0,
set key5: val5, |  | val3,val2,val1,val0,
set key6: val6, |  | val3,val2,val1,val0,
set key7: val7, |  | val3,val2,val1,val0,
set key8: val8, |  | val3,val2,val1,val0,
set key9: val9, |  | val3,val2,val1,val0,
get key0: val9, | val0, | val3,val2,val1,
get key1: val9, | val1,val0, | val3,val2,
get key2: val9, | val2,val1,val0, | val3,
get key3: val9, | val3,val2,val1, | val0,
get key9: val9, | val3,val2,val1, | val0,
at last: val9, | val3,val2,val1, | val0,
```